### PR TITLE
PlayersCount, OnPlayerLeft event before player object deletion and Peer configuration

### DIFF
--- a/MDHelpers/MDPeerConfigs.cs
+++ b/MDHelpers/MDPeerConfigs.cs
@@ -1,0 +1,40 @@
+using static Godot.NetworkedMultiplayerENet;
+
+public static class MDPeerConfigs
+{
+    private static bool _serverRelay = true;
+    private static bool _alwaysOrdered = false;
+    private static int _channelCount = 3;
+    private static CompressionModeEnum _compressionMode = CompressionModeEnum.None;
+    private static int _transferChannel = -1;
+
+    public static bool ServerRelay
+    {
+        get => _serverRelay;
+        set => _serverRelay = value;
+    }
+
+    public static bool AlwaysOrdered
+    {
+        get => _alwaysOrdered;
+        set => _alwaysOrdered = value;
+    }
+
+    public static int ChannelCount
+    {
+        get => _channelCount;
+        set => _channelCount = value;
+    }
+
+    public static CompressionModeEnum CompressionMode
+    {
+        get => _compressionMode;
+        set => _compressionMode = value;
+    }
+
+    public static int TransferChannel
+    {
+        get => _transferChannel;
+        set => _transferChannel = value;
+    }
+}

--- a/MDHelpers/MDPeerConfigs.cs
+++ b/MDHelpers/MDPeerConfigs.cs
@@ -2,39 +2,12 @@ using static Godot.NetworkedMultiplayerENet;
 
 public static class MDPeerConfigs
 {
-    private static bool _serverRelay = true;
-    private static bool _alwaysOrdered = false;
-    private static int _channelCount = 3;
-    private static CompressionModeEnum _compressionMode = CompressionModeEnum.None;
-    private static int _transferChannel = -1;
+    public static bool ServerRelay { get; set; } = true;
 
-    public static bool ServerRelay
-    {
-        get => _serverRelay;
-        set => _serverRelay = value;
-    }
+    public static bool AlwaysOrdered { get; set; } = false;
 
-    public static bool AlwaysOrdered
-    {
-        get => _alwaysOrdered;
-        set => _alwaysOrdered = value;
-    }
+    public static int ChannelCount { get; set; } = 3;
+    public static CompressionModeEnum CompressionMode { get; set; } = CompressionModeEnum.None;
 
-    public static int ChannelCount
-    {
-        get => _channelCount;
-        set => _channelCount = value;
-    }
-
-    public static CompressionModeEnum CompressionMode
-    {
-        get => _compressionMode;
-        set => _compressionMode = value;
-    }
-
-    public static int TransferChannel
-    {
-        get => _transferChannel;
-        set => _transferChannel = value;
-    }
+    public static int TransferChannel { get; set; } = -1;
 }

--- a/MDHelpers/MDStatics.cs
+++ b/MDHelpers/MDStatics.cs
@@ -102,6 +102,11 @@ public static class MDStatics
         return GetGameSession().GetNetworkMaster();
     }
 
+    public static int GetPlayersCount()
+    {
+        return GetGameSession().PlayersCount;
+    }
+
     // Gets the net mode of the local client
     public static MDNetMode GetNetMode()
     {

--- a/MDNetworking/MDGameSession.cs
+++ b/MDNetworking/MDGameSession.cs
@@ -25,6 +25,7 @@ public class MDGameSession : Node
     public MDGameInstance GameInstance = null;
 
     public bool IsSessionStarted { get; protected set; } = false;
+    public int PlayersCount => Players.Count;
 
     public string ExternalAddress { get; protected set; } = "";
 
@@ -290,8 +291,8 @@ public class MDGameSession : Node
 
     private void OnPlayerLeft_Internal(int PeerId)
     {
-        RemovePlayerObject(PeerId);
         OnPlayerLeftEvent(PeerId);
+        RemovePlayerObject(PeerId);
     }
 
     // Called when disconnected from the server or as the server

--- a/MDNetworking/MDGameSession.cs
+++ b/MDNetworking/MDGameSession.cs
@@ -85,7 +85,8 @@ public class MDGameSession : Node
         NetworkedMultiplayerENet peer = new NetworkedMultiplayerENet();
         peer.Connect("peer_connected", this, nameof(ServerOnPeerConnected));
         peer.Connect("peer_disconnected", this, nameof(ServerOnPeerDisconnected));
-
+        ConfigurePeer(peer);
+        
         Error error = peer.CreateServer(Port, MaxPlayers);
         bool Success = error == Error.Ok;
         MDLog.CLog(Success, LOG_CAT, MDLogLevel.Info, "Starting server on port {0} with {1} max players.", Port, MaxPlayers);
@@ -112,6 +113,7 @@ public class MDGameSession : Node
         peer.Connect("connection_succeeded", this, nameof(ClientOnConnected));
         peer.Connect("connection_failed", this, nameof(ClientOnFailedToConnect));
         peer.Connect("server_disconnected", this, nameof(ClientOnServerDisconnect));
+        ConfigurePeer(peer);
         
         Error error = peer.CreateClient(Address, Port);
         bool Success = error == Error.Ok;
@@ -124,6 +126,15 @@ public class MDGameSession : Node
         }
 
         return Success;
+    }
+
+    private void ConfigurePeer(NetworkedMultiplayerENet Peer)
+    {
+        Peer.ServerRelay = MDPeerConfigs.ServerRelay;
+        Peer.AlwaysOrdered = MDPeerConfigs.AlwaysOrdered;
+        Peer.ChannelCount = MDPeerConfigs.ChannelCount;
+        Peer.CompressionMode = MDPeerConfigs.CompressionMode;
+        Peer.TransferChannel = MDPeerConfigs.TransferChannel;
     }
 
     [MDCommand()]


### PR DESCRIPTION
This fixes #39
I was not sure how to implement peer configuring and i came up with another class with variables that player can edit before hosting/connecting and which will be used when hosting/connecting.