### PR TITLE
Setup CI against Godot 3.2.2 and Example Projects

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,6 @@ jobs:
         wget -O godot.zip https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/mono/Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64.zip
         sudo apt install unzip
         unzip godot.zip
-        chmod +x Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64
     
     - name: Clone Examples
       run: |
@@ -47,7 +46,6 @@ jobs:
         cd ../Examples
         export DOTNET_CLI_TELEMETRY_OPTOUT="true"
         dotnet build -c=Debug
-        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -v --build-solutions
         dotnet build -c=ExportRelease
 
   # Checks MDFramework changes against our example projects to check if there's any backwards compatibility issues.
@@ -68,7 +66,6 @@ jobs:
         wget -O godot.zip https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/mono/Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64.zip
         sudo apt install unzip
         unzip godot.zip
-        chmod +x Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64
     
     - name: Clone Examples
       run: |
@@ -85,5 +82,4 @@ jobs:
         cd ../Examples
         export DOTNET_CLI_TELEMETRY_OPTOUT="true"
         dotnet build -c=Debug
-        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -v --build-solutions
         dotnet build -c=ExportRelease

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,13 +20,13 @@ jobs:
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v1.5.0
 
-#     - name: Install Mono SDK
-#       run: |
-#         sudo apt install gnupg ca-certificates
-#         sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-#         echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
-#         sudo apt update
-#         sudo apt install mono-devel
+    - name: Install Mono SDK
+      run: |
+        sudo apt install gnupg ca-certificates
+        sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+        echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+        sudo apt update
+        sudo apt install mono-devel
     
     - name: Setup Godot
       run: |
@@ -40,12 +40,11 @@ jobs:
       run: |
         cd ..
         git clone https://github.com/DoubleDeez/MDFramework-Examples.git Examples
-        ls -al
         cp -R MDFramework/* Examples/MDFramework
-        ls -al Examples
-        ls -al Examples/MDFramework
         
     - name: Build Examples
       run: |
         cd ../Examples
+        ls -al
+        ls -al ../Godot_v${GODOT_VERSION}-stable_mono_x11_64/
         ../Godot_v${GODOT_VERSION}-stable_mono_x11_64/Godot_v${GODOT_VERSION}-stable_mono_x11.64 -e -q --build-solutions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,8 @@ env:
   GODOT_VERSION: 3.2.2
 
 jobs:
-  build:
+  empty-check:
+    name: Empty Project Check
     runs-on: ubuntu-20.04
 
     steps:
@@ -19,14 +20,45 @@ jobs:
     
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v1.5.0
+    
+    - name: Setup Godot
+      run: |
+        cd ..
+        wget -O godot.zip https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/mono/Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64.zip
+        sudo apt install unzip
+        unzip godot.zip
+        chmod +x Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64
+    
+    - name: Clone Examples
+      run: |
+        cd ..
+        git clone https://github.com/DoubleDeez/MDFramework-Examples.git Examples
+        cp -R MDFramework/* Examples/MDFramework
+        cd Examples
+        git checkout empty
+        
+    - name: Build Examples
+      run: |
+        cd ../Examples
+        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -d
+        dotnet build -c=Debug
+        dotnet build -c=ExportRelease
+        
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: Built Examples
+        path: /home/runner/work/MDFramework/Examples:
+  backwards-check:
+    name: Backwards Compatibility Check
+    runs-on: ubuntu-20.04
 
-#     - name: Install Mono SDK
-#       run: |
-#         sudo apt install gnupg ca-certificates
-#         sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-#         echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
-#         sudo apt update
-#         sudo apt install mono-devel
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+    
+    - name: Setup .NET Core SDK
+      uses: actions/setup-dotnet@v1.5.0
     
     - name: Setup Godot
       run: |
@@ -46,8 +78,8 @@ jobs:
       run: |
         cd ../Examples
         ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -d
-        dotnet build
-        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -d --build-solutions
+        dotnet build -c=Debug
+        dotnet build -c=ExportRelease
         
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
         export DOTNET_CLI_TELEMETRY_OPTOUT="true"
         dotnet build -c=Debug
         dotnet build -c=ExportRelease
-        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -v --build-solutions
+        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -v -l en --build-solutions
 
   # Checks MDFramework changes against our example projects to check if there's any backwards compatibility issues.
   backwards-check:
@@ -86,4 +86,4 @@ jobs:
         export DOTNET_CLI_TELEMETRY_OPTOUT="true"
         dotnet build -c=Debug
         dotnet build -c=ExportRelease
-        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -v --build-solutions
+        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -v -l en --build-solutions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ env:
   GODOT_VERSION: 3.2.2
 
 jobs:
+  # Checks MDFramework changes with an empty project to make sure it compiles
   empty-check:
     name: Empty Project Check
     runs-on: ubuntu-20.04
@@ -40,11 +41,12 @@ jobs:
     - name: Build Examples
       run: |
         cd ../Examples
-        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q
+        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -v
         export DOTNET_CLI_TELEMETRY_OPTOUT="true"
         dotnet build -c=Debug
-        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q --build-solutions
+        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -v --build-solutions
 
+  # Checks MDFramework changes against our example projects to check if there's any backwards compatibility issues.
   backwards-check:
     name: Backwards Compatibility Check
     runs-on: ubuntu-20.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,14 +43,6 @@ jobs:
         ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q
         export DOTNET_CLI_TELEMETRY_OPTOUT="true"
         dotnet build -c=Debug
-        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q --build-solutions
-        dotnet build -c=ExportRelease
-        
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: Built Examples
-        path: /home/runner/work/MDFramework/Examples
 
   backwards-check:
     name: Backwards Compatibility Check
@@ -83,11 +75,3 @@ jobs:
         ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q
         export DOTNET_CLI_TELEMETRY_OPTOUT="true"
         dotnet build -c=Debug
-        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q --build-solutions
-        dotnet build -c=ExportRelease
-        
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: Built Examples
-        path: /home/runner/work/MDFramework/Examples

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,3 +87,9 @@ jobs:
         dotnet build -c=Debug
         dotnet build -c=ExportRelease
         ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -v -l en --build-solutions
+    
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: Built Examples
+        path: /home/runner/work/MDFramework/Examples

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,8 +47,8 @@ jobs:
         cd ../Examples
         export DOTNET_CLI_TELEMETRY_OPTOUT="true"
         dotnet build -c=Debug
+        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -v --build-solutions
         dotnet build -c=ExportRelease
-        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -v -l en --build-solutions
 
   # Checks MDFramework changes against our example projects to check if there's any backwards compatibility issues.
   backwards-check:
@@ -85,5 +85,5 @@ jobs:
         cd ../Examples
         export DOTNET_CLI_TELEMETRY_OPTOUT="true"
         dotnet build -c=Debug
+        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -v --build-solutions
         dotnet build -c=ExportRelease
-        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -v -l en --build-solutions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,8 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: Built Examples
-        path: /home/runner/work/MDFramework/Examples:
+        path: /home/runner/work/MDFramework/Examples
+
   backwards-check:
     name: Backwards Compatibility Check
     runs-on: ubuntu-20.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,13 +17,13 @@ jobs:
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v1.5.0
 
-    - name: Install Mono SDK
-      run: |
-        sudo apt install gnupg ca-certificates
-        sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-        echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
-        sudo apt update
-        sudo apt install mono-devel
+#     - name: Install Mono SDK
+#       run: |
+#         sudo apt install gnupg ca-certificates
+#         sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+#         echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+#         sudo apt update
+#         sudo apt install mono-devel
     
     - name: Setup Godot
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,13 +20,13 @@ jobs:
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v1.5.0
 
-    - name: Install Mono SDK
-      run: |
-        sudo apt install gnupg ca-certificates
-        sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-        echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
-        sudo apt update
-        sudo apt install mono-devel
+#     - name: Install Mono SDK
+#       run: |
+#         sudo apt install gnupg ca-certificates
+#         sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+#         echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+#         sudo apt update
+#         sudo apt install mono-devel
     
     - name: Setup Godot
       run: |
@@ -45,6 +45,5 @@ jobs:
     - name: Build Examples
       run: |
         cd ../Examples
-        ls -al
-        ls -al ../Godot_v${GODOT_VERSION}-stable_mono_x11_64/
+        sudo apt-get install libpulse0:i386
         ../Godot_v${GODOT_VERSION}-stable_mono_x11_64/Godot_v${GODOT_VERSION}-stable_mono_x11.64 -e -q --build-solutions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,12 +38,14 @@ jobs:
     
     - name: Clone Examples
       run: |
+        cd ..
         git clone https://github.com/DoubleDeez/MDFramework-Examples.git Examples
         ls -al
         cp -R MDFramework/* Examples/MDFramework
         ls -al Examples
         ls -al Examples/MDFramework
-        cd Examples
         
     - name: Build Examples
-      run: ../Godot_v${GODOT_VERSION}-stable_mono_x11_64/Godot_v${GODOT_VERSION}-stable_mono_x11.64 -e -q --build-solutions
+      run: |
+        cd ../Examples
+        ../Godot_v${GODOT_VERSION}-stable_mono_x11_64/Godot_v${GODOT_VERSION}-stable_mono_x11.64 -e -q --build-solutions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,9 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
     
+    - name: Setup .NET Core SDK
+      uses: actions/setup-dotnet@v1.5.0
+    
     - name: setup-msbuild
       uses: microsoft/setup-msbuild@v1
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,15 +35,19 @@ jobs:
         cd ..
         git clone https://github.com/DoubleDeez/MDFramework-Examples.git Examples
         cp -R MDFramework/* Examples/MDFramework
+        mkdir -p Examples/.mono/assemblies/Debug
+        mkdir -p Examples/.mono/assemblies/Release
+        cp -R Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/GodotSharp/Api/Debug/* Examples/.mono/assemblies/Debug
+        cp -R Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/GodotSharp/Api/Release/* Examples/.mono/assemblies/Release
         cd Examples
         git checkout empty
         
     - name: Build Examples
       run: |
         cd ../Examples
-        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -v
         export DOTNET_CLI_TELEMETRY_OPTOUT="true"
         dotnet build -c=Debug
+        dotnet build -c=ExportRelease
         ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -v --build-solutions
 
   # Checks MDFramework changes against our example projects to check if there's any backwards compatibility issues.
@@ -71,10 +75,15 @@ jobs:
         cd ..
         git clone https://github.com/DoubleDeez/MDFramework-Examples.git Examples
         cp -R MDFramework/* Examples/MDFramework
+        mkdir -p Examples/.mono/assemblies/Debug
+        mkdir -p Examples/.mono/assemblies/Release
+        cp -R Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/GodotSharp/Api/Debug/* Examples/.mono/assemblies/Debug
+        cp -R Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/GodotSharp/Api/Release/* Examples/.mono/assemblies/Release
         
     - name: Build Examples
       run: |
         cd ../Examples
-        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q
         export DOTNET_CLI_TELEMETRY_OPTOUT="true"
         dotnet build -c=Debug
+        dotnet build -c=ExportRelease
+        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -v --build-solutions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,8 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
     
-#     - name: Setup .NET Core SDK
-#       uses: actions/setup-dotnet@v1.5.0
+    - name: Setup .NET Core SDK
+      uses: actions/setup-dotnet@v1.5.0
 
 #     - name: Install Mono SDK
 #       run: |
@@ -45,11 +45,11 @@ jobs:
     - name: Build Examples
       run: |
         cd ../Examples
-        pwd
+        dotnet build
         ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -d --build-solutions
         
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:
         name: DLLs
-        path: ${GITHUB_WORKSPACE}/../
+        path: /home/runner/work/MDFramework/Examples

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,9 +47,8 @@ jobs:
         cd ../Examples
         export DOTNET_CLI_TELEMETRY_OPTOUT="true"
         dotnet build -c=Debug
-        dotnet clean -c=Debug
         dotnet build -c=ExportRelease
-        dotnet clean -c=ExportRelease
+        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -v -l en --build-solutions
 
   # Checks MDFramework changes against our example projects to check if there's any backwards compatibility issues.
   backwards-check:
@@ -86,6 +85,5 @@ jobs:
         cd ../Examples
         export DOTNET_CLI_TELEMETRY_OPTOUT="true"
         dotnet build -c=Debug
-        dotnet clean -c=Debug
         dotnet build -c=ExportRelease
-        dotnet clean -c=ExportRelease
+        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -v -l en --build-solutions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   GODOT_VERSION: 3.2.2
-  GODOT_NAME: Godot_v3.2.2-stable_mono_x11_64
   EXAMPLE_REPO: https://github.com/DoubleDeez/MDFramework-Examples.git
 
 jobs:
@@ -32,21 +31,18 @@ jobs:
     
     - name: Setup Godot
       run: |
-        pwd
-        ls -al
-        cd ..
-        ls -al
-        wget -O godot.zip https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/mono/${GODOT_NAME}.zip
+        wget -O godot.zip https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/mono/Godot_v${GODOT_VERSION}-stable_mono_x11_64.zip
         sudo apt install unzip
         unzip godot.zip
-        chmod +x ${GODOT_NAME}/${GODOT_NAME}
+        chmod +x Godot_v${GODOT_VERSION}-stable_mono_x11_64/Godot_v${GODOT_VERSION}-stable_mono_x11.64
     
     - name: Clone Examples
       run: |
         git clone ${EXAMPLE_REPO} Examples
-        ls -al
+        cp -R MDFramework/ Examples/MDFramework/
         ls -al Examples
+        ls -al Examples/MDFramework
         cd Examples
         
     - name: Build Examples
-      run: ../${GODOT_NAME}/${GODOT_NAME} -e -q --build-solutions
+      run: ../Godot_v${GODOT_VERSION}-stable_mono_x11_64/Godot_v${GODOT_VERSION}-stable_mono_x11.64 -e -q --build-solutions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,9 +46,10 @@ jobs:
       run: |
         cd ../Examples
         sudo apt-get install pulseaudio
-        pwd
-        ls -al
-        ls -al MDFramework
+        echo "New"
+        cat MDFramework-Examples.csproj
+        echo "Old"
+        cat MDFramework-Examples.csproj.old
         ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -d --build-solutions
         
     - name: Upload Artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  GODOT_VERSION: 3.2.2
+  GODOT_NAME: Godot_v${GODOT_VERSION}-stable_mono_x11_64
+  EXAMPLE_REPO: https://github.com/DoubleDeez/MDFramework-Examples.git
+
 jobs:
   build:
     runs-on: ubuntu-20.04
@@ -27,8 +32,21 @@ jobs:
     
     - name: Setup Godot
       run: |
-        wget -O godot.zip https://downloads.tuxfamily.org/godotengine/3.2.2/mono/Godot_v3.2.2-stable_mono_x11_64.zip
+        pwd
+        ls -al
+        cd ..
+        ls -al
+        wget -O godot.zip https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/mono/${GODOT_NAME}.zip
         sudo apt install unzip
         unzip godot.zip
+        chmod +x ${GODOT_NAME}/${GODOT_NAME}
+    
+    - name: Clone Examples
+      run: |
+        git clone ${EXAMPLE_REPO} Examples
         ls -al
-        ls -al Godot_v3.2.2-stable_mono_x11_64
+        ls -al Examples
+        cd Examples
+        
+    - name: Build Examples
+      run: ../${GODOT_NAME}/${GODOT_NAME} -e -q --build-solutions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   GODOT_VERSION: 3.2.2
-  DOTNET_CLI_TELEMETRY_OPTOUT: 1
 
 jobs:
   empty-check:
@@ -41,7 +40,8 @@ jobs:
     - name: Build Examples
       run: |
         cd ../Examples
-        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -d
+        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q
+        export DOTNET_CLI_TELEMETRY_OPTOUT="true"
         dotnet build -c=Debug
         dotnet build -c=ExportRelease
         
@@ -79,7 +79,8 @@ jobs:
     - name: Build Examples
       run: |
         cd ../Examples
-        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -d
+        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q
+        export DOTNET_CLI_TELEMETRY_OPTOUT="true"
         dotnet build -c=Debug
         dotnet build -c=ExportRelease
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,7 @@ jobs:
         ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q
         export DOTNET_CLI_TELEMETRY_OPTOUT="true"
         dotnet build -c=Debug
+        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q --build-solutions
         dotnet build -c=ExportRelease
         
     - name: Upload Artifacts
@@ -82,6 +83,7 @@ jobs:
         ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q
         export DOTNET_CLI_TELEMETRY_OPTOUT="true"
         dotnet build -c=Debug
+        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q --build-solutions
         dotnet build -c=ExportRelease
         
     - name: Upload Artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,3 +24,11 @@ jobs:
         echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
         sudo apt update
         sudo apt install mono-devel
+    
+    - name: Setup Godot
+      run: |
+        wget -O godot.zip https://downloads.tuxfamily.org/godotengine/3.2.2/mono/Godot_v3.2.2-stable_mono_x11_64.zip
+        sudo apt install unzip
+        unzip godot.zip
+        ls -al
+        ls -al Godot_v3.2.2-stable_mono_x11_64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   GODOT_VERSION: 3.2.2
-  EXAMPLE_REPO: https://github.com/DoubleDeez/MDFramework-Examples.git
 
 jobs:
   build:
@@ -31,6 +30,7 @@ jobs:
     
     - name: Setup Godot
       run: |
+        cd ..
         wget -O godot.zip https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/mono/Godot_v${GODOT_VERSION}-stable_mono_x11_64.zip
         sudo apt install unzip
         unzip godot.zip
@@ -38,8 +38,9 @@ jobs:
     
     - name: Clone Examples
       run: |
-        git clone ${EXAMPLE_REPO} Examples
-        cp -R MDFramework/ Examples/MDFramework/
+        git clone https://github.com/DoubleDeez/MDFramework-Examples.git Examples
+        ls -al
+        cp -R MDFramework/* Examples/MDFramework
         ls -al Examples
         ls -al Examples/MDFramework
         cd Examples

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,21 +20,21 @@ jobs:
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v1.5.0
 
-#     - name: Install Mono SDK
-#       run: |
-#         sudo apt install gnupg ca-certificates
-#         sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-#         echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
-#         sudo apt update
-#         sudo apt install mono-devel
+    - name: Install Mono SDK
+      run: |
+        sudo apt install gnupg ca-certificates
+        sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+        echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+        sudo apt update
+        sudo apt install mono-devel
     
     - name: Setup Godot
       run: |
         cd ..
-        wget -O godot.zip https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/mono/Godot_v${GODOT_VERSION}-stable_mono_x11_64.zip
+        wget -O godot.zip https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/mono/Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64.zip
         sudo apt install unzip
         unzip godot.zip
-        chmod +x Godot_v${GODOT_VERSION}-stable_mono_x11_64/Godot_v${GODOT_VERSION}-stable_mono_x11.64
+        chmod +x Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64
     
     - name: Clone Examples
       run: |
@@ -46,4 +46,4 @@ jobs:
       run: |
         cd ../Examples
         sudo apt-get install pulseaudio
-        ../Godot_v${GODOT_VERSION}-stable_mono_x11_64/Godot_v${GODOT_VERSION}-stable_mono_x11.64 -e -q --build-solutions
+        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q --build-solutions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,11 @@ jobs:
     
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v1.5.0
-    
-    - name: setup-msbuild
-      uses: microsoft/setup-msbuild@v1
 
-    - name: Run a one-line script
-      run: echo Hello, world!
+    - name: Install Mono SDK
+      run: |
+        sudo apt install gnupg ca-certificates
+        sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+        echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+        sudo apt update
+        sudo apt install mono-devel

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,11 +45,12 @@ jobs:
     - name: Build Examples
       run: |
         cd ../Examples
+        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -d
         dotnet build
         ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -d --build-solutions
         
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: DLLs
+        name: Built Examples
         path: /home/runner/work/MDFramework/Examples

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   GODOT_VERSION: 3.2.2
-  GODOT_NAME: Godot_v${GODOT_VERSION}-stable_mono_x11_64
+  GODOT_NAME: Godot_v3.2.2-stable_mono_x11_64
   EXAMPLE_REPO: https://github.com/DoubleDeez/MDFramework-Examples.git
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,8 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
     
-    - name: Setup .NET Core SDK
-      uses: actions/setup-dotnet@v1.5.0
+#     - name: Setup .NET Core SDK
+#       uses: actions/setup-dotnet@v1.5.0
 
 #     - name: Install Mono SDK
 #       run: |
@@ -45,15 +45,10 @@ jobs:
     - name: Build Examples
       run: |
         cd ../Examples
-        sudo apt-get install pulseaudio
-        echo "New"
-        cat MDFramework-Examples.csproj
-        echo "Old"
-        cat MDFramework-Examples.csproj.old
         ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -d --build-solutions
         
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:
         name: DLLs
-        path: ../Examples/.mono/temp/bin/
+        path: ${GITHUB_WORKSPACE}/../Examples/.mono/temp/bin/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,5 +45,5 @@ jobs:
     - name: Build Examples
       run: |
         cd ../Examples
-        sudo apt-get install libpulse0:i386
+        sudo apt-get install pulseaudio
         ../Godot_v${GODOT_VERSION}-stable_mono_x11_64/Godot_v${GODOT_VERSION}-stable_mono_x11.64 -e -q --build-solutions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+    
+    - name: setup-msbuild
+      uses: microsoft/setup-msbuild@v1
+
+    - name: Run a one-line script
+      run: echo Hello, world!

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,7 @@ jobs:
         ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q
         export DOTNET_CLI_TELEMETRY_OPTOUT="true"
         dotnet build -c=Debug
+        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q --build-solutions
 
   backwards-check:
     name: Backwards Compatibility Check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,8 +47,9 @@ jobs:
         cd ../Examples
         export DOTNET_CLI_TELEMETRY_OPTOUT="true"
         dotnet build -c=Debug
+        dotnet clean -c=Debug
         dotnet build -c=ExportRelease
-        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -v -l en --build-solutions
+        dotnet clean -c=ExportRelease
 
   # Checks MDFramework changes against our example projects to check if there's any backwards compatibility issues.
   backwards-check:
@@ -85,11 +86,6 @@ jobs:
         cd ../Examples
         export DOTNET_CLI_TELEMETRY_OPTOUT="true"
         dotnet build -c=Debug
+        dotnet clean -c=Debug
         dotnet build -c=ExportRelease
-        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -v -l en --build-solutions
-    
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: Built Examples
-        path: /home/runner/work/MDFramework/Examples
+        dotnet clean -c=ExportRelease

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,10 +45,11 @@ jobs:
     - name: Build Examples
       run: |
         cd ../Examples
+        pwd
         ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -d --build-solutions
         
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:
         name: DLLs
-        path: ${GITHUB_WORKSPACE}/../Examples/.mono/temp/bin/
+        path: ${GITHUB_WORKSPACE}/../

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,13 +20,13 @@ jobs:
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v1.5.0
 
-    - name: Install Mono SDK
-      run: |
-        sudo apt install gnupg ca-certificates
-        sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-        echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
-        sudo apt update
-        sudo apt install mono-devel
+#     - name: Install Mono SDK
+#       run: |
+#         sudo apt install gnupg ca-certificates
+#         sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+#         echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+#         sudo apt update
+#         sudo apt install mono-devel
     
     - name: Setup Godot
       run: |
@@ -46,4 +46,13 @@ jobs:
       run: |
         cd ../Examples
         sudo apt-get install pulseaudio
-        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q --build-solutions
+        pwd
+        ls -al
+        ls -al MDFramework
+        ../Godot_v${GODOT_VERSION}-stable_mono_linux_headless_64/Godot_v${GODOT_VERSION}-stable_mono_linux_headless.64 -e -q -d --build-solutions
+        
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: DLLs
+        path: ../Examples/.mono/temp/bin/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   GODOT_VERSION: 3.2.2
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
 
 jobs:
   empty-check:

--- a/MDGameInstance.cs
+++ b/MDGameInstance.cs
@@ -40,8 +40,6 @@ namespace MD
             CreateInterfaceManager();
 
             RegisterNodeAndChildren(GetTree().Root);
-
-            this is obviously broken code
         }
 
         public override void _Notification(int NotificationType)

--- a/MDGameInstance.cs
+++ b/MDGameInstance.cs
@@ -40,6 +40,8 @@ namespace MD
             CreateInterfaceManager();
 
             RegisterNodeAndChildren(GetTree().Root);
+
+            this is obviously broken code
         }
 
         public override void _Notification(int NotificationType)


### PR DESCRIPTION
Fixes #15 

Empty project is a required check to merge as all it does is build an empty project with MDFramework. The backwards compatibility check will let us know if our changes break any of the examples' code