### PR TITLE
Fixes for server authoritative setups

### DIFF
--- a/MDGameSynchronizer/MDGameClock.cs
+++ b/MDGameSynchronizer/MDGameClock.cs
@@ -83,9 +83,12 @@ namespace MD
             // TODO: Remove this, only here for debug
             MDOnScreenDebug.AddOnScreenDebugInfo("GameClock Current Tick", () => CurrentTick.ToString());
             MDOnScreenDebug.AddOnScreenDebugInfo("OS GetTickMsec", () => OS.GetTicksMsec().ToString());
-            MDOnScreenDebug.AddOnScreenDebugInfo("GameClock Remote Offset", () => CurrentRemoteTickOffset.ToString());
+            MDOnScreenDebug.AddOnScreenDebugInfo("GameClock Remote Offset",
+                () =>
+                    $"{CurrentRemoteTickOffset} ({(int) (CurrentRemoteTickOffset * TICK_INTERVAL_MILLISECONDS)} Msec)");
             MDOnScreenDebug.AddOnScreenDebugInfo("GameClock Remote Target Offset",
-                () => CurrentRemoteTickOffsetTarget.ToString());
+                () =>
+                    $"{CurrentRemoteTickOffsetTarget} ({(int) (CurrentRemoteTickOffsetTarget * TICK_INTERVAL_MILLISECONDS)} Msec)");
         }
 
         public override void _ExitTree()

--- a/MDGameSynchronizer/MDGameSynchronizer.cs
+++ b/MDGameSynchronizer/MDGameSynchronizer.cs
@@ -70,7 +70,7 @@ namespace MD
         protected int NodeCount = -1;
 
         protected bool NodeSynchCompleted = false;
-        private int MaxPing;
+        protected int MaxPing;
 
 
         // Called when the node enters the scene tree for the first time.
@@ -530,11 +530,18 @@ namespace MD
             }
 
             // Send ping request
-            uint ping = (uint) GetPlayerPing(PeerId);
-            int maxPlayerPing = GetMaxPlayerPing() + (int) ping;
-            uint estimate = GetPlayerTicksMsec(PeerId) + ping;
-            RpcId(PeerId, nameof(RequestPing), OS.GetTicksMsec(), estimate, GameClock.GetTickAtTimeOffset(ping),
-                maxPlayerPing);
+            if (GameClock == null)
+            {
+                RpcId(PeerId, nameof(RequestPing), OS.GetTicksMsec());
+            }
+            else
+            {
+                uint ping = (uint) GetPlayerPing(PeerId);
+                int maxPlayerPing = GetMaxPlayerPing() + (int) ping;
+                uint estimate = GetPlayerTicksMsec(PeerId) + ping;
+                RpcId(PeerId, nameof(RequestPing), OS.GetTicksMsec(), estimate, GameClock.GetTickAtTimeOffset(ping),
+                    maxPlayerPing);
+            }
         }
 
         private void CheckAllClientsSynched(Timer timer)


### PR DESCRIPTION
This fixes #51 and most likely #49

If we disable `server relay`, then client can't make RPC's to eachother. 
Before this PR, each client would ping eachother to calculate remote offsets on their side. Now it's pinging through server. 
There still need for max ping to be not the same for each player (#55), but this is start.