### PR TITLE
Refactor of Game Synchronizer

### DIFF
--- a/MDExtensions/MDNodeExtensions.cs
+++ b/MDExtensions/MDNodeExtensions.cs
@@ -417,6 +417,7 @@ namespace MD
         /// <param name="ConnectionTarget">The object to attach the timeout method to</param>
         /// <param name="MethodName">The name of the timeout method</param>
         /// <param name="Parameters">Array of parameters to pass to the timeout function</param>
+        /// <returns>The new timer</returns>
         public static Timer CreateTimer(this Node Instance, String Name, bool OneShot, float WaitTime,
             bool TimerAsFirstArgument, Godot.Object ConnectionTarget, String MethodName, params object[] Parameters)
         {
@@ -436,6 +437,27 @@ namespace MD
 
             timer.Connect("timeout", ConnectionTarget, MethodName, new Godot.Collections.Array(parameters));
             Instance.AddChild(timer);
+            return timer;
+        }
+
+        /// <summary>
+        /// Creates a timer that still runs while game is paused
+        /// </summary>
+        /// <param name="Instance">The Instance from where this function called</param>
+        /// <param name="Name">The name of the timer</param>
+        /// <param name="OneShot">Is this a one shot timer</param>
+        /// <param name="WaitTime">Duration of the timer</param>
+        /// <param name="TimerAsFirstArgument">Should we pass the timer as the first argument to the timeout method?</param>
+        /// <param name="ConnectionTarget">The object to attach the timeout method to</param>
+        /// <param name="MethodName">The name of the timeout method</param>
+        /// <param name="Parameters">Array of parameters to pass to the timeout function</param>
+        /// <returns>The new timer</returns>
+        public static Timer CreateUnpausableTimer(this Node Instance, string TimerName, bool OneShot, float WaitTime, bool TimerAsFirstArgument,
+            Godot.Object ConnectionTarget, string MethodName, params object[] Parameters)
+        {
+            Timer timer = Instance.CreateTimer(TimerName, OneShot, WaitTime, 
+                                                TimerAsFirstArgument, ConnectionTarget, MethodName, Parameters);
+            timer.PauseMode = Node.PauseModeEnum.Process;
             return timer;
         }
 

--- a/MDGameSynchronizer/MDGameSynchPeerInfo.cs
+++ b/MDGameSynchronizer/MDGameSynchPeerInfo.cs
@@ -108,6 +108,9 @@ namespace MD
             }
         }
 
+        /// <summary>
+        /// Called when the ping timer times out, sends a ping request to the given client.
+        /// </summary>
         public void OnPingTimerTimeout()
         {
             // Check if network is still active

--- a/MDGameSynchronizer/MDGameSynchPeerInfo.cs
+++ b/MDGameSynchronizer/MDGameSynchPeerInfo.cs
@@ -1,0 +1,233 @@
+using Godot;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MD
+{
+    /// <summary>
+    /// This class is used by the GameSynchronizer to keep track of a single peer.
+    /// </summary>
+    public class MDGameSynchPeerInfo
+    {
+        private const string LOG_CAT = "LogGameSynchPeerInfo";
+
+        // We don't want to have to read config all the time
+        protected int SettingAveragePingToKeep = 0;
+
+        /// <summary>List of estimated ping times</summary>
+        protected Queue<int> PingList = new Queue<int>();
+
+        /// <summary>List of estiamted OS.GetTicksMSec offsets</summary>
+        protected List<int> TicksList = new List<int>();
+
+        /// <summary>The average estimated OS.GetTicksMSec offset for this peer</summary>
+        public int TickMSecOffset { get; set; }
+
+        /// <summary>The average estimated ping for this peer</summary>
+        public int Ping { get; set;}
+
+        /// <summary>Has this peer completed the node sync</summary>
+        public bool CompletedNodeSynch { get; set;}
+
+        /// <summary>Has this peer completed synching</summary>
+        public bool CompletedSynch { get; set;}
+
+        public int PeerId {get; private set; }
+
+        protected MDGameSynchronizer GameSynchronizer;
+
+        protected Timer PingTimer;
+
+        public MDGameSynchPeerInfo(MDGameSynchronizer GameSynchronizer, int PeerId)
+        {
+            MDLog.AddLogCategoryProperties(LOG_CAT, new MDLogProperties(MDLogLevel.Force));
+            MDLog.Info(LOG_CAT, $"Creating MDGameSynchPeerInfo for Peer [ID: {PeerId}]");
+            this.GameSynchronizer = GameSynchronizer;
+            this.PeerId = PeerId;
+            this.SettingAveragePingToKeep = GameSynchronizer.GetPingsToKeepForAverage();
+            this.CompletedNodeSynch = false;
+            this.CompletedSynch = false;
+            StartMSecCycle();
+        }
+
+        /// <summary>
+        /// Cleanup
+        /// </summary>
+        public void Dispose()
+        {
+            MDOnScreenDebug.RemoveOnScreenDebugInfo($"Ping({PeerId})");
+            if (Godot.Object.IsInstanceValid(PingTimer))
+            {
+                PingTimer.Stop();
+                PingTimer.RemoveAndFree();
+            }
+        }
+
+        #region Public Methods
+
+        /// <summary>
+        /// Called when a response for OS.GetTicksMsec() comes back
+        /// </summary>
+        /// <param name="ClientTicksMsec">The Os.GetTicksMsec() time at the client when they sent the response</param>
+        /// <param name="ServerTimeOfRequest">The time we sent the request to the client</param>
+        /// <param name="RequestNumber">The request number of this request</param>
+        public void ProcessMSecResponse(uint ClientTicksMsec, uint ServerTimeOfRequest, int RequestNumber)
+        {
+            // Get and record ping
+            int ping = (int) (OS.GetTicksMsec() - ServerTimeOfRequest);
+            PushPlayerPingToQueue(ping);
+
+            // Calculate ping for one way trip (Ping / 2)
+            long pingOneWay = (long) (Mathf.Floor(ping) / 2f);
+
+            /* Estimation is <Client TickMsec> - <Server TickMsec> + <Ping Half Time> = <Estimated Current Offset To Client>
+                Example:
+                ClientTime when request was recieved = 3000
+                ServerTime when response came = 5000
+                Ping for rountrip = 500.
+                    If we assume the packet took the same time back and forth it means 
+                    the client is half of the ping time ahead of it's answer when we get the answer (ie. should now be 3000 + 250 = 3250).
+                
+                3000 - 5000 + 250 = -1750 is the estimated offset
+                5000 - 1750 = 3250 which we think the time is at this moment at the client.
+    
+                Of course this is a best guess estimate, by doing multiple measurements and taking the average we can close in on the truth.
+            */
+            int estimatedGetTicksOffset = (int) (ClientTicksMsec - OS.GetTicksMsec() + pingOneWay);
+            PushPlayerEstimatedTicksMSecToList(estimatedGetTicksOffset);
+
+            // Check if we are done with the initial request burst
+            if (RequestNumber < GameSynchronizer.GetInitialMeasurementCount())
+            {
+                SendRequestToPlayer(++RequestNumber);
+            }
+            else
+            {
+                StartClientPingCycle();
+            }
+        }
+
+        public void OnPingTimerTimeout()
+        {
+            // Check if network is still active
+            if (!MDStatics.IsNetworkActive())
+            {
+                MDLog.Trace(LOG_CAT, $"Network is no longer active");
+                return;
+            }
+
+            // Send ping request
+            if (GameSynchronizer.GameClock == null)
+            {
+                GameSynchronizer.RpcId(PeerId, MDGameSynchronizer.METHOD_REQUEST_PING, OS.GetTicksMsec());
+            }
+            else
+            {
+                int maxPlayerPing = GameSynchronizer.GetMaxPlayerPing() + (int) Ping;
+                uint estimate = GameSynchronizer.GetPlayerTicksMsec(PeerId) + (uint)Ping;
+                GameSynchronizer.RpcId(PeerId, MDGameSynchronizer.METHOD_REQUEST_PING, OS.GetTicksMsec(), estimate, 
+                                GameSynchronizer.GameClock.GetTickAtTimeOffset(Ping), maxPlayerPing);
+            }
+        }
+
+        ///<summary>Adds the ping to the players ping list and removes any overflow</summary>
+        public void PushPlayerPingToQueue(int Ping)
+        {
+            PingList.Enqueue(Ping);
+            MDLog.Trace(LOG_CAT, $"Peer [{PeerId}] recorded a ping of {Ping}");
+            if (PingList.Count > SettingAveragePingToKeep)
+            {
+                PingList.Dequeue();
+            }
+
+            CalculatePlayerAveragePing();
+        }
+
+        /// <summary>
+        /// Check if we got enough of a confidence value in the Msec value of the client to resume the game
+        /// </summary>
+        /// <returns>True if we are ready to resume, false if not</returns>
+        public bool IsClientMSecConfident()
+        {
+            if (TicksList.Count >= GameSynchronizer.GetMinimumMeasurementCountBeforeResume())
+            {
+                return true;
+            }
+            
+            MDLog.Trace(LOG_CAT, $"Still waiting for peer [{PeerId}] to get a more secure TickMsec value");
+            return false;
+        }
+
+        #endregion
+
+        #region Network Methods
+
+        private void StartMSecCycle()
+        {
+            // Sends a request to the given player for the OS.GetTicksMsec time
+            if (GameSynchronizer.GetInitialMeasurementCount() > 0)
+            {
+                SendRequestToPlayer(1);
+            }
+        }
+
+        private void SendRequestToPlayer(int ReuqestNumber)
+        {
+            GameSynchronizer.RpcId(PeerId, MDGameSynchronizer.METHOD_REQUEST_TICKS_MSEC, ReuqestNumber, OS.GetTicksMsec());
+        }
+
+        #endregion
+
+        #region Support Methods
+
+        ///<summary>Starts the player ping request cycle</summary>
+        private void StartClientPingCycle()
+        {
+            if (!GameSynchronizer.IsActivePingEnabled())
+            {
+                return;
+            }
+
+            // Onscreen debug for ping
+            MDOnScreenDebug.AddOnScreenDebugInfo($"Ping({PeerId})",
+                () => MDStatics.GetGameSynchronizer().GetPlayerPing(PeerId).ToString());
+
+            PingTimer = GameSynchronizer.CreateUnpausableTimer($"PingTimer{PeerId}", false, GameSynchronizer.GetPingInterval(), 
+                                            false, GameSynchronizer, MDGameSynchronizer.METHOD_ON_PING_TIMER_TIMEOUT, PeerId);
+            PingTimer.Start();
+        }
+
+        ///<summary>Calculate the player average ping</summary>
+        private void CalculatePlayerAveragePing()
+        {
+            int estimate = PingList.Sum();
+            estimate /= PingList.Count;
+
+            Ping = estimate;
+            GameSynchronizer.SendPlayerPingEvent(PeerId, Ping);
+        }
+
+        ///<summary>Adds the estimated ticks msec to the players list</summary>
+        private void PushPlayerEstimatedTicksMSecToList(int EstimatedTicksMsec)
+        {
+            MDLog.Trace(LOG_CAT, $"Peer [{PeerId}] recorded a estimated msec of {EstimatedTicksMsec}");
+            TicksList.Add(EstimatedTicksMsec);
+            CalculatePlayerEstimatedTicksMSecOffset();
+        }
+
+
+        ///<summary>Calculate the player estimated offset for OS.GetTicksMSec</summary>
+        private void CalculatePlayerEstimatedTicksMSecOffset()
+        {
+            int estimate = TicksList.Sum();
+            estimate /= TicksList.Count;
+
+            TickMSecOffset = estimate;
+            MDLog.Debug(LOG_CAT,
+                $"Estimated OS.GetTicksMsec offset for peer [{PeerId}] is {estimate} based on {TicksList.Count} measurements");
+        }
+
+        #endregion
+    }
+}

--- a/MDGameSynchronizer/MDGameSynchPeerInfo.cs
+++ b/MDGameSynchronizer/MDGameSynchPeerInfo.cs
@@ -41,7 +41,7 @@ namespace MD
 
         public MDGameSynchPeerInfo(MDGameSynchronizer GameSynchronizer, int PeerId)
         {
-            MDLog.AddLogCategoryProperties(LOG_CAT, new MDLogProperties(MDLogLevel.Force));
+            MDLog.AddLogCategoryProperties(LOG_CAT, new MDLogProperties(MDLogLevel.Info));
             MDLog.Info(LOG_CAT, $"Creating MDGameSynchPeerInfo for Peer [ID: {PeerId}]");
             this.GameSynchronizer = GameSynchronizer;
             this.PeerId = PeerId;

--- a/MDGameSynchronizer/MDGameSynchronizer.cs
+++ b/MDGameSynchronizer/MDGameSynchronizer.cs
@@ -19,6 +19,10 @@ namespace MD
     [MDAutoRegister]
     public class MDGameSynchronizer : Node
     {
+        public const string METHOD_REQUEST_TICKS_MSEC = nameof(RequestTicksMsec);
+        public const string METHOD_ON_PING_TIMER_TIMEOUT = nameof(OnPingTimerTimeout);
+        public const string METHOD_REQUEST_PING = nameof(RequestPing);
+        
         private const string LOG_CAT = "LogGameSynchronizer";
 
         private const string RESUME_TIMER_NAME = "ResumeTimer";
@@ -49,34 +53,22 @@ namespace MD
 
         public MDGameSession GameSession = null;
 
-        ///<Summary>Stores the latest ping response times for each player</summary>
-        protected Dictionary<int, Queue<int>> InternalPingList = new Dictionary<int, Queue<int>>();
-
-        ///<Summary>Stores all the estimated GetTicksMsec offsets for all players</summary>
-        protected Dictionary<int, List<int>> InternalTicksList = new Dictionary<int, List<int>>();
-
-        ///<Summary>This contains what we think is the GetTicksMsec offset for each player</summary>
-        protected Dictionary<int, int> PlayerTicksMsecOffset = new Dictionary<int, int>();
-
-        ///<Summary>This contains what we think is the ping for each player</summary>
-        protected Dictionary<int, int> PlayerPing = new Dictionary<int, int>();
+        ///<Summary>List containing synch information per peer</summary>
+        protected Dictionary<int, MDGameSynchPeerInfo> PeerSynchInfo = new Dictionary<int, MDGameSynchPeerInfo>();
 
         protected List<Node> NodeList = new List<Node>();
-
-        protected List<int> ClientSynchList = new List<int>();
-
-        protected List<int> CompletedNodeSyncList = new List<int>();
 
         protected int NodeCount = -1;
 
         protected bool NodeSynchCompleted = false;
+        
         protected int MaxPing;
 
 
         // Called when the node enters the scene tree for the first time.
         public override void _Ready()
         {
-            MDLog.AddLogCategoryProperties(LOG_CAT, new MDLogProperties(MDLogLevel.Info));
+            MDLog.AddLogCategoryProperties(LOG_CAT, new MDLogProperties(MDLogLevel.Force));
             GameSession = GameInstance.GetGameSession();
             GameSession.OnPlayerJoinedEvent += OnPlayerJoinedEvent;
             GameSession.OnPlayerLeftEvent += OnPlayerLeftEvent;
@@ -90,9 +82,9 @@ namespace MD
         /// <summary> Returns the ping for the given peer or -1 if the peer does not exist.</summary>
         public int GetPlayerPing(int PeerId)
         {
-            if (PlayerPing.ContainsKey(PeerId))
+            if (PeerSynchInfo.ContainsKey(PeerId))
             {
-                return PlayerPing[PeerId];
+                return PeerSynchInfo[PeerId].Ping;
             }
 
             MDLog.Warn(LOG_CAT, $"Requested ping for peer [{PeerId}] that doesn't exist in list");
@@ -102,15 +94,15 @@ namespace MD
         ///<summary>Returns the highest ping we got to any player</summary>
         public int GetMaxPlayerPing()
         {
-            return MDStatics.IsClient() ? MaxPing : PlayerPing.Values.Max();
+            return MDStatics.IsClient() ? MaxPing : PeerSynchInfo.Select(p => p.Value.Ping).Max();
         }
 
         /// <summary> Returns the estimated OS.GetTicksMsec for the given peer or 0 if the peer does not exist.</summary>
         public uint GetPlayerTicksMsec(int PeerId)
         {
-            if (PlayerTicksMsecOffset.ContainsKey(PeerId))
+            if (PeerSynchInfo.ContainsKey(PeerId))
             {
-                return Convert.ToUInt32(OS.GetTicksMsec() + PlayerTicksMsecOffset[PeerId]);
+                return Convert.ToUInt32(OS.GetTicksMsec() + PeerSynchInfo[PeerId].TickMSecOffset);
             }
 
             MDLog.Warn(LOG_CAT, $"Requested OS.GetTicksMsec for peer [{PeerId}] that doesn't exist in list");
@@ -119,7 +111,11 @@ namespace MD
 
         public bool HasPeerCompletedNodeSynch(int PeerId)
         {
-            return CompletedNodeSyncList.Contains(PeerId);
+            if (!PeerSynchInfo.ContainsKey(PeerId))
+            {
+                return false;
+            }
+            return PeerSynchInfo[PeerId].CompletedNodeSynch;
         }
 
         #endregion
@@ -133,7 +129,7 @@ namespace MD
             this.NodeCount = NodeCount;
             NodeSynchCompleted = false;
             // Start synch timer
-            Timer timer = CreateUnpausableTimer("SynchTimer", false, SYNCH_TIMER_CHECK_INTERVAL, true, this,
+            Timer timer = this.CreateUnpausableTimer("SynchTimer", false, SYNCH_TIMER_CHECK_INTERVAL, true, this,
                 nameof(CheckSynchStatus));
             timer.Start();
 
@@ -168,9 +164,9 @@ namespace MD
         {
             // Great this client is done
             MDLog.Debug(LOG_CAT, $"Peer [{Multiplayer.GetRpcSenderId()}] completed synch");
-            if (!ClientSynchList.Contains(Multiplayer.GetRpcSenderId()))
+            if (PeerSynchInfo.ContainsKey(Multiplayer.GetRpcSenderId()))
             {
-                ClientSynchList.Add(Multiplayer.GetRpcSenderId());
+                PeerSynchInfo[Multiplayer.GetRpcSenderId()].CompletedSynch = true;
             }
 
             // Send status update to all players so they can update UI
@@ -227,7 +223,7 @@ namespace MD
         protected void PingResponse(uint ServerTimeOfRequest)
         {
             int ping = (int) (OS.GetTicksMsec() - ServerTimeOfRequest);
-            PushPlayerPingToQueue(Multiplayer.GetRpcSenderId(), ping);
+            PeerSynchInfo[Multiplayer.GetRpcSenderId()].PushPlayerPingToQueue(ping);
         }
 
         ///<summary>Requests the OS.GetTicksMsec() from the client</summary>
@@ -235,7 +231,6 @@ namespace MD
         protected void RequestTicksMsec(int RequestNumber, uint ServerTimeOfRequest)
         {
             // Respond
-
             RpcId(GameSession.GetNetworkMaster(), nameof(ResponseTicksMsec), OS.GetTicksMsec(), ServerTimeOfRequest,
                 RequestNumber);
             MDLog.Trace(LOG_CAT,
@@ -247,40 +242,8 @@ namespace MD
         protected void ResponseTicksMsec(uint ClientTicksMsec, uint ServerTimeOfRequest, int RequestNumber)
         {
             MDLog.Debug(LOG_CAT,
-                "Msec response number {RequestNumber} from peer [{Multiplayer.GetRpcSenderId()}] is {ClientTicksMsec} local Msec is {OS.GetTicksMsec()}");
-            // Get and record ping
-            int ping = (int) (OS.GetTicksMsec() - ServerTimeOfRequest);
-            PushPlayerPingToQueue(Multiplayer.GetRpcSenderId(), ping);
-
-            // Calculate ping for one way trip (Ping / 2)
-            long pingOneWay = (long) (Mathf.Floor(ping) / 2f);
-
-            /* Estimation is <Client TickMsec> - <Server TickMsec> + <Ping Half Time> = <Estimated Current Offset To Client>
-                Example:
-                ClientTime when request was recieved = 3000
-                ServerTime when response came = 5000
-                Ping for rountrip = 500.
-                    If we assume the packet took the same time back and forth it means 
-                    the client is half of the ping time ahead of it's answer when we get the answer (ie. should now be 3000 + 250 = 3250).
-                
-                3000 - 5000 + 250 = -1750 is the estimated offset
-                5000 - 1750 = 3250 which we think the time is at this moment at the client.
-    
-                Of course this is a best guess estimate, by doing multiple measurements and taking the average we can close in on the truth.
-            */
-            int estimatedGetTicksOffset = (int) (ClientTicksMsec - OS.GetTicksMsec() + pingOneWay);
-            PushPlayerEstimatedTicksMSecToList(Multiplayer.GetRpcSenderId(), estimatedGetTicksOffset);
-            CalculatePlayerEstimatedTicksMSecOffset(Multiplayer.GetRpcSenderId());
-
-            // Check if we are done with the initial request burst
-            if (RequestNumber < GetInitialMeasurementCount())
-            {
-                SendRequestToPlayer(Multiplayer.GetRpcSenderId(), ++RequestNumber);
-            }
-            else
-            {
-                StartClientPingCycle(Multiplayer.GetRpcSenderId());
-            }
+                $"Msec response number {RequestNumber} from peer [{Multiplayer.GetRpcSenderId()}] is {ClientTicksMsec} local Msec is {OS.GetTicksMsec()}");
+            PeerSynchInfo[Multiplayer.GetRpcSenderId()].ProcessMSecResponse(ClientTicksMsec, ServerTimeOfRequest, RequestNumber);
         }
 
         [Puppet]
@@ -303,7 +266,10 @@ namespace MD
             else
             {
                 // Only clear the list if synching isn't already in progress
-                ClientSynchList.Clear();
+                foreach (MDGameSynchPeerInfo peerInfo in PeerSynchInfo.Values)
+                {
+                    peerInfo.CompletedSynch = false;
+                }
             }
         }
 
@@ -312,7 +278,7 @@ namespace MD
         {
             float waitTime = (UnpauseTime - OS.GetTicksMsec()) / 1000f;
             MDLog.Trace(LOG_CAT, $"Unpausing game in {waitTime}");
-            Timer timer = CreateUnpausableTimer(RESUME_TIMER_NAME, true, waitTime, true, this,
+            Timer timer = this.CreateUnpausableTimer(RESUME_TIMER_NAME, true, waitTime, true, this,
                 nameof(OnUnpauseTimerTimeout));
             timer.Start();
             OnSynchCompleteEvent(waitTime);
@@ -327,9 +293,9 @@ namespace MD
         {
             // Called from client the first time they complete their node synch
             MDLog.Trace(LOG_CAT, $"Peer [{Multiplayer.GetRpcSenderId()}] has completed node synchronization");
-            if (!CompletedNodeSyncList.Contains(Multiplayer.GetRpcSenderId()))
+            if (!PeerSynchInfo.ContainsKey(Multiplayer.GetRpcSenderId()))
             {
-                CompletedNodeSyncList.Add(Multiplayer.GetRpcSenderId());
+                PeerSynchInfo[Multiplayer.GetRpcSenderId()].CompletedNodeSynch = true;
             }
         }
 
@@ -337,87 +303,9 @@ namespace MD
 
         #region SUPPORTING METHODS
 
-        ///<summary>Sends a request to the given player for the OS.GetTicksMsec time</summary>
-        private void SendRequestToPlayer(int PeerId, int RequestNumber)
-        {
-            RpcId(PeerId, nameof(RequestTicksMsec), RequestNumber, OS.GetTicksMsec());
-        }
-
-        ///<summary>Adds the estimated ticks msec to the players list</summary>
-        private void PushPlayerEstimatedTicksMSecToList(int PeerId, int EstimatedTicksMsec)
-        {
-            if (!InternalTicksList.ContainsKey(PeerId))
-            {
-                InternalTicksList.Add(PeerId, new List<int>());
-            }
-
-            MDLog.Trace(LOG_CAT, $"Peer [{PeerId}] recorded a estimated msec of {EstimatedTicksMsec}");
-            InternalTicksList[PeerId].Add(EstimatedTicksMsec);
-        }
-
-        ///<summary>Adds the ping to the players ping list and removes any overflow</summary>
-        private void PushPlayerPingToQueue(int PeerId, int Ping)
-        {
-            if (!InternalPingList.ContainsKey(PeerId))
-            {
-                InternalPingList.Add(PeerId, new Queue<int>());
-            }
-
-            InternalPingList[PeerId].Enqueue(Ping);
-            MDLog.Trace(LOG_CAT, $"Peer [{PeerId}] recorded a ping of {Ping}");
-            if (InternalPingList[PeerId].Count > GetPingsToKeepForAverage())
-            {
-                InternalPingList[PeerId].Dequeue();
-            }
-
-            CalculatePlayerPing(PeerId);
-        }
-
-        ///<summary>Calculate the player average ping</summary>
-        private void CalculatePlayerPing(int PeerId)
-        {
-            int estimate = InternalPingList[PeerId].Sum();
-
-            estimate /= InternalPingList[PeerId].Count;
-            SetPlayerPing(PeerId, estimate);
-        }
-
-
-        ///<summary>Calculate the player estimated offset for OS.GetTicksMSec</summary>
-        private void CalculatePlayerEstimatedTicksMSecOffset(int PeerId)
-        {
-            int totalEstimate = InternalTicksList[PeerId].Sum();
-            totalEstimate /= InternalTicksList[PeerId].Count;
-            SetPlayerEstimatedOffset(PeerId, totalEstimate);
-            MDLog.Debug(LOG_CAT,
-                $"Estimated OS.GetTicksMsec offset for peer [{PeerId}] is {totalEstimate} based on {InternalTicksList[PeerId].Count} measurements");
-        }
-
-        ///<summary>Set the estimated offset for the player</summary>
-        private void SetPlayerEstimatedOffset(int PeerId, int Estimate)
-        {
-            if (!PlayerTicksMsecOffset.ContainsKey(PeerId))
-            {
-                PlayerTicksMsecOffset.Add(PeerId, Estimate);
-            }
-            else
-            {
-                PlayerTicksMsecOffset[PeerId] = Estimate;
-            }
-        }
-
         ///<summary>Set the ping for the player</summary>
-        private void SetPlayerPing(int PeerId, int Ping)
+        public void SendPlayerPingEvent(int PeerId, int Ping)
         {
-            if (!PlayerPing.ContainsKey(PeerId))
-            {
-                PlayerPing.Add(PeerId, Ping);
-            }
-            else
-            {
-                PlayerPing[PeerId] = Ping;
-            }
-
             OnPlayerPingUpdatedEvent(PeerId, Ping);
         }
 
@@ -435,27 +323,21 @@ namespace MD
                 return;
             }
 
-            // Send our first request and start timer
-            if (GetInitialMeasurementCount() > 0)
-            {
-                SendRequestToPlayer(PeerId, 1);
-            }
+            MDGameSynchPeerInfo PeerInfo = new MDGameSynchPeerInfo(this, PeerId);
+            PeerSynchInfo.Add(PeerId, PeerInfo);
 
-            if (PeerId != MDStatics.GetServerId())
+            PauseGame();
+            OnSynchStartedEvent(IsPauseOnJoin());
+            foreach (int peerid in GameSession.GetAllPeerIds().Where(peerid => peerid != MDStatics.GetServerId()))
             {
-                PauseGame();
-                OnSynchStartedEvent(IsPauseOnJoin());
-                foreach (int peerid in GameSession.GetAllPeerIds().Where(peerid => peerid != MDStatics.GetServerId()))
+                // Synch just started so set everyone to 0%
+                OnPlayerSynchStatusUpdateEvent(peerid, 0f);
+
+                // Don't do this for the connecting peer or the server
+                if (PeerId != peerid)
                 {
-                    // Synch just started so set everyone to 0%
-                    OnPlayerSynchStatusUpdateEvent(peerid, 0f);
-
-                    // Don't do this for the connecting peer or the server
-                    if (PeerId != peerid)
-                    {
-                        RpcId(peerid, nameof(PauseGame));
-                        RpcId(peerid, nameof(RpcReceiveNodeCount), NodeList.Count);
-                    }
+                    RpcId(peerid, nameof(PauseGame));
+                    RpcId(peerid, nameof(RpcReceiveNodeCount), NodeList.Count);
                 }
             }
 
@@ -465,7 +347,7 @@ namespace MD
             Timer timer = (Timer) GetNodeOrNull(ALL_PLAYERS_SYNCHED_TIMER_NAME);
             if (timer == null)
             {
-                timer = CreateUnpausableTimer(ALL_PLAYERS_SYNCHED_TIMER_NAME, false, SYNCH_TIMER_CHECK_INTERVAL, true,
+                timer = this.CreateUnpausableTimer(ALL_PLAYERS_SYNCHED_TIMER_NAME, false, SYNCH_TIMER_CHECK_INTERVAL, true,
                     this, nameof(CheckAllClientsSynched));
                 timer.Start();
             }
@@ -473,13 +355,11 @@ namespace MD
 
         private void OnPlayerLeftEvent(int PeerId)
         {
-            InternalPingList.Remove(PeerId);
-            InternalTicksList.Remove(PeerId);
-            PlayerTicksMsecOffset.Remove(PeerId);
-            PlayerPing.Remove(PeerId);
-            CompletedNodeSyncList.Remove(PeerId);
-            ClientSynchList.Remove(PeerId);
-            MDOnScreenDebug.RemoveOnScreenDebugInfo("Ping(" + PeerId + ")");
+            if (PeerSynchInfo.ContainsKey(PeerId))
+            {
+                PeerSynchInfo[PeerId].Dispose();
+                PeerSynchInfo.Remove(PeerId);
+            }
         }
 
         private void OnSessionStartedEvent()
@@ -498,98 +378,24 @@ namespace MD
             GameClock?.SetCurrentTick(0);
         }
 
-        ///<summary>Starts the player ping request cycle</summary>
-        private void StartClientPingCycle(int PeerId)
+        private void OnPingTimerTimeout(int PeerId)
         {
-            if (!IsActivePingEnabled())
+            if (PeerSynchInfo.ContainsKey(PeerId))
             {
-                return;
-            }
-
-            if (!InternalPingList.ContainsKey(PeerId))
-            {
-                InternalPingList.Add(PeerId, new Queue<int>());
-            }
-
-            MDOnScreenDebug.AddOnScreenDebugInfo($"Ping({PeerId})",
-                () => MDStatics.GetGameSynchronizer().GetPlayerPing(PeerId).ToString());
-            Timer timer = CreateUnpausableTimer($"PingTimer{PeerId}", false, GetPingInterval(), true, this,
-                nameof(OnPingTimerTimeout), PeerId);
-            timer.Start();
-        }
-
-        private void OnPingTimerTimeout(Timer timer, int PeerId)
-        {
-            // Check if peer is still active
-            if (!InternalPingList.ContainsKey(PeerId) || !MDStatics.IsNetworkActive())
-            {
-                MDLog.Trace(LOG_CAT, $"Peer {PeerId} has disconnected, stopping ping");
-                timer.Stop();
-                timer.RemoveAndFree();
-                return;
-            }
-
-            // Send ping request
-            if (GameClock == null)
-            {
-                RpcId(PeerId, nameof(RequestPing), OS.GetTicksMsec());
-            }
-            else
-            {
-                uint ping = (uint) GetPlayerPing(PeerId);
-                int maxPlayerPing = GetMaxPlayerPing() + (int) ping;
-                uint estimate = GetPlayerTicksMsec(PeerId) + ping;
-                RpcId(PeerId, nameof(RequestPing), OS.GetTicksMsec(), estimate, GameClock.GetTickAtTimeOffset(ping),
-                    maxPlayerPing);
+                PeerSynchInfo[PeerId].OnPingTimerTimeout();
             }
         }
 
         private void CheckAllClientsSynched(Timer timer)
         {
-            if (ClientSynchList.Count < GameSession.GetAllPlayerInfos().Count - 1)
+            if (PeerSynchInfo.Values.Where(peerInfo => peerInfo.CompletedSynch == false).ToList().Count > 0)
             {
                 MDLog.Debug(LOG_CAT, "All clients are not synched yet");
                 return;
             }
 
-            // Double check each client, if another client left while we were synching
-            // We could believe we are synched while we really are not
-            bool allClientsSynched = true;
-            foreach (int peerId in GameSession.GetAllPeerIds())
-            {
-                if (peerId == MDStatics.GetServerId()
-                    || ClientSynchList.Contains(peerId) && PlayerTicksMsecOffset.ContainsKey(peerId))
-                {
-                    continue;
-                }
-
-                MDLog.Trace(LOG_CAT, $"Peer [{peerId}] is not yet fully synched");
-                allClientsSynched = false;
-            }
-
-            if (!allClientsSynched)
-            {
-                MDLog.Debug(LOG_CAT, "All peers are not synched yet");
-                return;
-            }
-
-            bool waitForTickMsec = false;
-
             // Check if we still need to wait for a better confidence on the TickMsec value
-            foreach (int peerId in GameSession.GetAllPeerIds())
-            {
-                if (peerId == MDStatics.GetServerId()
-                    || InternalTicksList.ContainsKey(peerId) &&
-                    InternalTicksList[peerId].Count >= GetMinimumMeasurementCountBeforeResume())
-                {
-                    continue;
-                }
-
-                waitForTickMsec = true;
-                MDLog.Trace(LOG_CAT, $"Still waiting for peer [{peerId}] to get a more secure TickMsec value");
-            }
-
-            if (waitForTickMsec)
+            if (PeerSynchInfo.Values.Where(peerInfo => peerInfo.IsClientMSecConfident() == false).ToList().Count > 0)
             {
                 MDLog.Debug(LOG_CAT, "Still waiting for a more secure msec value");
                 return;
@@ -610,7 +416,7 @@ namespace MD
             }
 
             UnpauseAtTickMsec(OS.GetTicksMsec() + GetUnpauseCountdownDurationMSec(), 0);
-            ClientSynchList.Clear();
+            PeerSynchInfo.Values.ToList().ForEach(value => value.CompletedSynch = false);
             timer.RemoveAndFree();
         }
 
@@ -702,16 +508,6 @@ namespace MD
             GetTree().Paused = false;
         }
 
-        private Timer CreateUnpausableTimer(string TimerName, bool OneShot, float WaitTime, bool TimerAsFirstArgument,
-            Godot.Object ConnectionTarget, string MethodName, params object[] Parameters)
-        {
-            Timer timer = this.CreateTimer(TimerName, OneShot, WaitTime, TimerAsFirstArgument, ConnectionTarget,
-                MethodName,
-                Parameters);
-            timer.PauseMode = PauseModeEnum.Process;
-            return timer;
-        }
-
         #endregion
 
         #region VIRTUAL METHODS
@@ -735,32 +531,32 @@ namespace MD
         }
 
         /// <summary>How often do we ping each client (Default: 0.5f)</summary>
-        protected virtual float GetPingInterval()
+        public virtual float GetPingInterval()
         {
             return float.Parse(this.GetConfiguration().GetString(MDConfiguration.ConfigurationSections.GameSynchronizer, MDConfiguration.PING_INTERVAL, "0.5"));
         }
 
         /// <summary>Pings to keep for getting average (Default: 10)</summary>
-        protected virtual int GetPingsToKeepForAverage()
+        public virtual int GetPingsToKeepForAverage()
         {
             return this.GetConfiguration().GetInt(MDConfiguration.ConfigurationSections.GameSynchronizer, MDConfiguration.PINGS_TO_KEEP_FOR_AVERAGE, 10);
         }
 
         /// <summary>If set to true we will ping every player continuously. (Default: true)
         /// <para>You can set the interval with <see cref="GetPingInterval"/></para></summary>
-        protected virtual bool IsActivePingEnabled()
+        public virtual bool IsActivePingEnabled()
         {
             return this.GetConfiguration().GetBool(MDConfiguration.ConfigurationSections.GameSynchronizer, MDConfiguration.ACTIVE_PING_ENABLED, true);
         }
 
         /// <summary>This decides how many times we go back and forth to establish the OS.GetTicksMsec offset for each client (Default: 20)</summary>
-        protected virtual int GetInitialMeasurementCount()
+        public virtual int GetInitialMeasurementCount()
         {
             return this.GetConfiguration().GetInt(MDConfiguration.ConfigurationSections.GameSynchronizer, MDConfiguration.INITIAL_MEASUREMENT_COUNT, 20);
         }
 
         /// <summary>If IsPauseOnJoin() is enabled we will wait for at least this level of security for TicksMsec before we resume (Default: GetInitialMeasurementCount() / 2)</summary>
-        protected virtual int GetMinimumMeasurementCountBeforeResume()
+        public virtual int GetMinimumMeasurementCountBeforeResume()
         {
             return this.GetConfiguration().GetInt(MDConfiguration.ConfigurationSections.GameSynchronizer, MDConfiguration.INITIAL_MEASUREMENT_COUNT_BEFORE_RESUME, 10);
         }

--- a/MDGameSynchronizer/MDGameSynchronizer.cs
+++ b/MDGameSynchronizer/MDGameSynchronizer.cs
@@ -19,6 +19,11 @@ namespace MD
     [MDAutoRegister]
     public class MDGameSynchronizer : Node
     {
+        public enum SynchronizationStates
+        {
+            SYNCHRONIZING_IN_PROGRESS,
+            SYNCRHONIZED
+        }
         public const string METHOD_REQUEST_TICKS_MSEC = nameof(RequestTicksMsec);
         public const string METHOD_ON_PING_TIMER_TIMEOUT = nameof(OnPingTimerTimeout);
         public const string METHOD_REQUEST_PING = nameof(RequestPing);
@@ -64,6 +69,8 @@ namespace MD
         
         protected int MaxPing;
 
+        public SynchronizationStates SynchronizationState { get; private set;}
+
 
         // Called when the node enters the scene tree for the first time.
         public override void _Ready()
@@ -75,6 +82,7 @@ namespace MD
             GameSession.OnNetworkNodeAdded += OnNetworkNodeAdded;
             GameSession.OnNetworkNodeRemoved += OnNetworkNodeRemoved;
             GameSession.OnSessionStartedEvent += OnSessionStartedEvent;
+            SynchronizationState = SynchronizationStates.SYNCHRONIZING_IN_PROGRESS;
         }
 
         #region PUBLIC METHODS
@@ -372,6 +380,11 @@ namespace MD
                 MDOnScreenDebug.AddOnScreenDebugInfo($"MaxRoundtripPing: ",
                     () => MaxPing.ToString());
                 PauseGame();
+                SynchronizationState = SynchronizationStates.SYNCHRONIZING_IN_PROGRESS;
+            }
+            else
+            {
+                SynchronizationState = SynchronizationStates.SYNCRHONIZED;
             }
 
             // Reset to tick 0 at start of session
@@ -482,6 +495,7 @@ namespace MD
             if (SynchedNodes == NodeCount)
             {
                 // We are done synching
+                SynchronizationState = SynchronizationStates.SYNCRHONIZED;
                 RpcId(MDStatics.GetServerId(), nameof(ClientSynchDone));
                 MDLog.Debug(LOG_CAT, "We are done synching notifying server");
                 // Set ourselves to done

--- a/MDGameSynchronizer/MDGameSynchronizer.cs
+++ b/MDGameSynchronizer/MDGameSynchronizer.cs
@@ -68,7 +68,7 @@ namespace MD
         // Called when the node enters the scene tree for the first time.
         public override void _Ready()
         {
-            MDLog.AddLogCategoryProperties(LOG_CAT, new MDLogProperties(MDLogLevel.Force));
+            MDLog.AddLogCategoryProperties(LOG_CAT, new MDLogProperties(MDLogLevel.Info));
             GameSession = GameInstance.GetGameSession();
             GameSession.OnPlayerJoinedEvent += OnPlayerJoinedEvent;
             GameSession.OnPlayerLeftEvent += OnPlayerLeftEvent;

--- a/MDNetworking/MemberImpl/MDReplicatedCommandReplicator.cs
+++ b/MDNetworking/MemberImpl/MDReplicatedCommandReplicator.cs
@@ -33,7 +33,7 @@ namespace MD
         public override void SetValues(uint Tick, params object[] Parameters)
         {
             // If we got no GameClock or the tick this update is for is past the current tick
-            if (GameClock == null || GameClock.GetRemoteTick() >= Tick)
+            if (GameClock == null || GameClock.GetRemoteTick() >= Tick || IsSynchInProgress())
             {
                 GetCommandReplicator().MDProcessCommand(Parameters);
                 if (OnValueChangedCallback != null)

--- a/MDNetworking/MemberImpl/MDReplicatedMember.cs
+++ b/MDNetworking/MemberImpl/MDReplicatedMember.cs
@@ -26,6 +26,7 @@ namespace MD
         protected bool IsShouldReplicate = false;
         protected MDReplicator Replicator;
         protected MDGameSession GameSession;
+        protected MDGameSynchronizer GameSynchronizer;
         protected MDGameClock GameClock;
         protected IMDDataConverter DataConverter = null;
         protected MethodInfo OnValueChangedCallback = null;
@@ -37,6 +38,7 @@ namespace MD
             GameSession = MDStatics.GetGameSession();
             Replicator = GameSession.Replicator;
             GameClock = GameSession.GetGameClock();
+            GameSynchronizer = GameSession.GetGameSynchronizer();
 
             this.Member = Member;
             this.Reliable = Reliable;
@@ -152,7 +154,8 @@ namespace MD
         public virtual void SetValues(uint Tick, params object[] Parameters)
         {
             // If we got no GameClock or the tick this update is for is past the current tick
-            if (GameClock == null || GameClock.GetRemoteTick() >= Tick)
+            // Or if we are currently synching
+            if (GameClock == null || GameClock.GetRemoteTick() >= Tick || IsSynchInProgress())
             {
                 UpdateValue(Parameters);
             }
@@ -265,6 +268,16 @@ namespace MD
         protected object ConvertFromObject(object CurrentObject, object[] Parameters)
         {
             return DataConverter.CovertBackToObject(CurrentObject, (object[])Parameters);
+        }
+
+        protected bool IsSynchInProgress()
+        {
+            if (GameSynchronizer == null || GameSynchronizer.SynchronizationState == MDGameSynchronizer.SynchronizationStates.SYNCRHONIZED)
+            {
+                return false;
+            } 
+
+            return true;
         }
     }
 }


### PR DESCRIPTION
The game synchronizer had 4 lists that used PeerId as key, I moved all of these into it's own object along with a lot of the logic. This was just to make the game synchronizer more understandable. No logic has been changed.